### PR TITLE
Remove local import

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"./figletlib"
+	"github.com/lukesampson/figlet/figletlib"
 )
 
 const (


### PR DESCRIPTION
`go get github.com/lukesampson/figlet` fails with
`$GOPATH\src\github.com\lukesampson\figlet\main.go:11:2: local import "./figletlib" in non-local package` this change fixes it