### PR TITLE
add ReadFontFromBytes

### DIFF
--- a/figletlib/fonts.go
+++ b/figletlib/fonts.go
@@ -117,6 +117,10 @@ func ReadFont(filename string) (*Font, error) {
 		return nil, err
 	}
 
+	return ReadFontFromBytes(bytes)
+}
+
+func ReadFontFromBytes(bytes []byte) (*Font, error) {
 	lines := strings.Split(string(bytes), "\n")
 
 	header, err := readHeader(lines[0])


### PR DESCRIPTION
closes https://github.com/lukesampson/figlet/issues/6

Here's how you can use this with [go-bindata](https://github.com/jteeuwen/go-bindata).

First, create the `fonts.go` file with all the fonts:

```bash
go get -u github.com/jteeuwen/go-bindata/...
go-bindata \
    -o fonts.go \
    -prefix "${GOPATH:=~/go}/src/github.com/rgl/figlet/figletlib" \
    "${GOPATH:=~/go}/src/github.com/rgl/figlet/figletlib/fonts"
```

Then use it in go with something like:

```golang
var font *figletlib.Font

func init() {
	font = mustReadFont("fonts/slant.flf")
}

func mustReadFont(filename string) *figletlib.Font {
	f, err := figletlib.ReadFontFromBytes(MustAsset(filename))
	if err != nil {
		panic(err)
	}
	return f
}
```