### PR TITLE
Ensure header is trimmed before trying to parse integer

### DIFF
--- a/figletlib/fonts.go
+++ b/figletlib/fonts.go
@@ -30,7 +30,8 @@ func readHeader(header string) (fontHeader, error) {
 		return h, fmt.Errorf("invalid font header: %v", header)
 	}
 
-	headerParts := strings.Split(header[len(magic_num):], " ")
+	trimmedHeader := strings.TrimSpace(header[len(magic_num):])
+	headerParts := strings.Split(trimmedHeader, " ")
 	h.hardblank = []rune(headerParts[0])[0]
 
 	nums := make([]int, len(headerParts)-1)


### PR DESCRIPTION
Hi there!

I noticed some fonts were not being rendered when they had CRLF line endings. Instead of normalising all fonts, I think `figlet` should be a little more forgiving. This PR ensures the read header has spaces trimmed before it attempts to use `strconv.ParseInt`

An example of font that wasn't being rendered is [`Big Money-ne`](https://github.com/xero/figlet-fonts/blob/master/Big%20Money-ne.flf), which yields the following error:

```strconv.ParseInt: parsing "25\r": invalid syntaxer: flf2a& 11 8 18 0 25```

Getting rid of the carriage return fixes the problem. 